### PR TITLE
Lesson7: add terraform puppet_agent resource and add autosign

### DIFF
--- a/Lesson7/main.tf
+++ b/Lesson7/main.tf
@@ -69,7 +69,7 @@ resource "aws_security_group_rule" "create-sgr-outbound" {
 }
 
 resource "aws_instance" "puppet" {
-  count         = 2 
+  count         = 2
   ami           = data.aws_ami.ubuntu.id
   instance_type = "t2.micro"
   key_name      = aws_key_pair.deployer.key_name
@@ -88,24 +88,27 @@ resource "null_resource" "puppet_master" {
     }
 
     provisioner "file" {
-	source      = "${path.cwd}/files/ex7File.pp"
+      source      = "${path.cwd}/files/ex7File.pp"
     	destination = "/tmp/ex7File.pp"
     }
     provisioner "remote-exec" {
-	inline = [
-		"sudo apt-get update -y",
-		"sudo su -c 'echo \"${aws_instance.puppet.*.public_ip[0]} ${aws_instance.puppet.*.private_dns[0]} puppet\" >> /etc/hosts'",
-		"sudo su -c 'echo \"${aws_instance.puppet.*.public_ip[1]} ${aws_instance.puppet.*.private_dns[1]}\" >> /etc/hosts'",
-		"wget https://apt.puppetlabs.com/puppet6-release-focal.deb",
-		"sudo dpkg -i puppet6-release-focal.deb",
-		"sudo apt-get update -y",
-		"sudo apt-get install puppetserver -y",
-		"sudo sed -i '9s#.*#JAVA_ARGS=\"-Xms512m -Xmx512m -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger\"#' /etc/default/puppetserver",
-		"sudo systemctl start puppetserver",
-		"sudo systemctl enable puppetserver",
-		"sudo mkdir -p /etc/puppet/code/environments/production/manifests",
-		"sudo cp /tmp/ex7File.pp /etc/puppet/code/environments/production/manifests/ex7File.pp" 
-    	]
+      inline = [
+        "sudo apt-get update -y",
+        "sudo su -c 'echo \"${aws_instance.puppet.*.public_ip[0]} ${aws_instance.puppet.*.private_dns[0]} puppet\" >> /etc/hosts'",
+        "sudo su -c 'echo \"${aws_instance.puppet.*.public_ip[1]} ${aws_instance.puppet.*.private_dns[1]}\" >> /etc/hosts'",
+        "sudo /opt/puppetlabs/bin/puppet config set certname ${aws_instance.puppet.*.private_dns[0]} --section main",
+        "sudo /opt/puppetlabs/bin/puppet config set dns_alt_names puppet,${aws_instance.puppet.*.private_dns[0]} --section master",
+        "sudo /opt/puppetlabs/bin/puppet config set autosign true --section master",
+        "wget https://apt.puppetlabs.com/puppet6-release-focal.deb",
+        "sudo dpkg -i puppet6-release-focal.deb",
+        "sudo apt-get update -y",
+        "sudo apt-get install puppetserver -y",
+        "sudo sed -i '9s#.*#JAVA_ARGS=\"-Xms512m -Xmx512m -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger\"#' /etc/default/puppetserver",
+        "sudo systemctl start puppetserver",
+        "sudo systemctl enable puppetserver",
+        "sudo mkdir -p /etc/puppetlabs/code/environments/production/manifests",
+        "sudo cp /tmp/ex7File.pp /etc/puppetlabs/code/environments/production/manifests/ex7File.pp"
+      ]
     }
 
 
@@ -142,11 +145,24 @@ resource "null_resource" "puppet_certs" {
       private_key = tls_private_key.private-key.private_key_pem
     }
     provisioner "remote-exec" {
-	inline = [
-		"sudo /opt/puppetlabs/bin/puppetserver ca list --all",
-		"sudo /opt/puppetlabs/bin/puppetserver ca sign --all",
-		"sudo /opt/puppetlabs/bin/puppet agent --test",
-	]
+      inline = [
+        "sudo /opt/puppetlabs/bin/puppetserver ca list --all",
+      ]
+    }
+}
+
+resource "null_resource" "puppet_agent" {
+    depends_on = [ null_resource.puppet_certs ]
+    connection {
+      host = aws_instance.puppet.*.public_ip[1]
+      user = "ubuntu"
+      type = "ssh"
+      private_key = tls_private_key.private-key.private_key_pem
+    }
+    provisioner "remote-exec" {
+      inline = [
+          "sudo /opt/puppetlabs/bin/puppet agent --test ",
+      ]
     }
 }
 
@@ -156,12 +172,12 @@ resource "null_resource" "puppet_certs" {
 # On Puppet Client: find /var/lib/puppet -name *yourhostnamehere* -delete
 # On Puppet Client: puppent agent -tf
 # On Puppet Master: sudo /opt/puppetlabs/bin/puppetserver ca list --all
-#                    sudo /opt/puppetlabs/bin/puppetserver ca sign --all", 
+#                    sudo /opt/puppetlabs/bin/puppetserver ca sign --all",
 
 # Logging into instance
 # terraform apply -auto-approve
 # terraform output -raw private-key > ~/.ssh/student.pem
-# chmod 600 ~/.ssh/student.pem 
+# chmod 600 ~/.ssh/student.pem
 # puppet-master: ssh -i ~/.ssh/student.pem ubuntu@$(terraform output -raw puppet-master)
 # puppet-client: ssh -i ~/.ssh/student.pem ubuntu@$(terraform output -raw puppet-cient)
-# terraform destroy -auto-approve 
+# terraform destroy -auto-approve


### PR DESCRIPTION
Lesson7 had some problems during terraform apply:
- `puppet ca sign -all` was very prone to failure because puppet client was not ready or was signed already (with autosign).
- `puppet agent -test` was run in puppet master, so puppet client